### PR TITLE
INTGR-991: The Datafeed example from Dotnet sample displays "No data" in the terminal, but it still saves a file with the data

### DIFF
--- a/DataFeed/DataFeed.csproj
+++ b/DataFeed/DataFeed.csproj
@@ -11,6 +11,6 @@
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Geotab.Checkmate.ObjectModel" Version="11.7.179" />
+    <PackageReference Include="Geotab.Checkmate.ObjectModel" Version="11.43.302" />
   </ItemGroup>
 </Project>

--- a/DataFeed/FeedToConsole.cs
+++ b/DataFeed/FeedToConsole.cs
@@ -17,7 +17,7 @@ namespace Geotab.SDK.DataFeed
         const string StatusDataHeader = "Vehicle Serial Number, Date, Diagnostic Name, Source Name, Value, Units";
         const string TripHeader = "VehicleName, VehicleSerialNumber, Vin, Driver Name, Driver Keys, Trip Start Time, Trip End Time, Trip Distance";
 
-        const string ExceptionEventHeader = "Id, Vehicle Name, Vehicle Serial Number, VIN, Diagnostic Name, Diagnostic Code, Source Name, Driver Name, Driver Keys, Rule Name,sActive From, Active To";
+        const string ExceptionEventHeader = "Id, Vehicle Name, Vehicle Serial Number, VIN, Diagnostic Name, Diagnostic Code, Source Name, Driver Name, Driver Keys, Rule Name, Active From, Active To";
 
         static readonly char[] trimChars = { ' ', ',' };
         readonly IDictionary<Id, Device> deviceLookup = new Dictionary<Id, Device>();
@@ -223,8 +223,8 @@ namespace Geotab.SDK.DataFeed
             StringBuilder sb = new StringBuilder();
             AppendDeviceValues(sb, logRecord.Device.Id);
             AppendValues(sb, logRecord.DateTime);
-            AppendValues(sb, Math.Round(logRecord.Longitude, 3));
-            AppendValues(sb, Math.Round(logRecord.Latitude, 3));
+            AppendValues(sb, Math.Round((decimal)(logRecord.Longitude?? 0.0), 3)); 
+            AppendValues(sb, Math.Round((decimal)(logRecord.Latitude?? 0.0), 3)); 
             AppendValues(sb, logRecord.Speed);
             Console.WriteLine(sb.ToString().TrimEnd(trimChars));
         }

--- a/DataFeed/FeedToCsv.cs
+++ b/DataFeed/FeedToCsv.cs
@@ -125,6 +125,10 @@ namespace Geotab.SDK.DataFeed
             {
                 WriteDataToCsv<ExceptionEvent>();
             }
+            if ((faultRecords.Count == 0)&& (statusRecords.Count == 0) && (gpsRecords.Count == 0) && (trips.Count == 0) && (exceptionEvents.Count == 0))
+            {
+                NoDataError();
+            }
         }
 
         static void AppendDeviceValues(StringBuilder sb, Device device)
@@ -186,6 +190,10 @@ namespace Geotab.SDK.DataFeed
             StringBuilder sb = new StringBuilder();
             action(sb, entity);
             writer.WriteLine(sb.ToString().TrimEnd(','));
+        }
+
+        void NoDataError(){
+            Console.WriteLine("Unable to Generate CSV: No data found");
         }
 
         void WriteDataToCsv<T>()

--- a/DataFeed/Worker.cs
+++ b/DataFeed/Worker.cs
@@ -33,7 +33,7 @@ namespace Geotab.SDK.DataFeed
             // Optionally we can output to csv or google doc:
             new FeedToCsv(path, results.GpsRecords, results.StatusData, results.FaultData, results.Trips, results.ExceptionEvents).Run();
             // Displays feed to console
-            new FeedToConsole(results.GpsRecords,results.StatusData,results.FaultData).Run();
+            new FeedToConsole(results.GpsRecords,results.StatusData,results.FaultData, results.Trips, results.ExceptionEvents).Run();
                         
             await Task.Delay(1000);
         }


### PR DESCRIPTION
Added the functionality to the FeedToConsole file to address the bug. Now the class has been expanded so that Trip data and Exception events can be printed to the console. Updated the error messages to make sense as well. 